### PR TITLE
disabled unused stuff

### DIFF
--- a/arch/arm64/boot/dts/qcom/comma3.dtsi
+++ b/arch/arm64/boot/dts/qcom/comma3.dtsi
@@ -116,7 +116,8 @@
 };
 
 &vendor {
-  main3v3: main3v3 {
+  // the 3v3 is always on, not on GPIO 27
+  /*main3v3: main3v3 {
     status = "ok";
 
     compatible = "regulator-fixed";
@@ -127,7 +128,7 @@
     gpio = <&tlmm 27 0>;
     enable-active-high;
     regulator-always-on;
-  };
+  };*/
 
   main5v: main5v {
     status = "ok";

--- a/arch/arm64/boot/dts/qcom/sdm845-camera-sensor-mtp.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-camera-sensor-mtp.dtsi
@@ -52,7 +52,7 @@
 		status = "ok";
 	};
 
-	actuator_regulator: gpio-regulator@0 {
+	/*actuator_regulator: gpio-regulator@0 {
 		compatible = "regulator-fixed";
 		reg = <0x00 0x00>;
 		regulator-name = "actuator_regulator";
@@ -62,7 +62,7 @@
 		enable-active-high;
 		gpio = <&tlmm 27 0>;
 		vin-supply = <&pmi8998_bob>;
-	};
+	};*/
 
 	camera_rear_ldo: gpio-regulator@1 {
 		compatible = "regulator-fixed";
@@ -122,7 +122,7 @@
 		pinctrl-1 = <&cam_res_mgr_suspend>;
 	};
 
-	actuator_rear: qcom,actuator@0 {
+	/*actuator_rear: qcom,actuator@0 {
 		cell-index = <0>;
 		reg = <0x0>;
 		compatible = "qcom,actuator";
@@ -290,7 +290,7 @@
 		clock-names = "cam_clk";
 		clock-cntl-level = "turbo";
 		clock-rates = <24000000>;
-	};
+	};*/
 
 	qcom,cam-sensor@0 {
 		cell-index = <0>;


### PR DESCRIPTION
The issue is it needs a camerad change:

```
diff --git a/selfdrive/camerad/cameras/camera_qcom2.cc b/selfdrive/camerad/cameras/camera_qcom2.cc
index 2812922a..450fc6db 100644
--- a/selfdrive/camerad/cameras/camera_qcom2.cc
+++ b/selfdrive/camerad/cameras/camera_qcom2.cc
@@ -594,13 +594,13 @@ static void camera_open(CameraState *s) {
   // /dev/v4l-subdev10 is sensor, 11, 12, 13 are the other sensors
   switch (s->camera_num) {
     case 0:
-      s->sensor_fd = open("/dev/v4l-subdev10", O_RDWR | O_NONBLOCK);
+      s->sensor_fd = open("/dev/v4l-subdev7", O_RDWR | O_NONBLOCK);
       break;
     case 1:
-      s->sensor_fd = open("/dev/v4l-subdev11", O_RDWR | O_NONBLOCK);
+      s->sensor_fd = open("/dev/v4l-subdev8", O_RDWR | O_NONBLOCK);
       break;
     case 2:
-      s->sensor_fd = open("/dev/v4l-subdev12", O_RDWR | O_NONBLOCK);
+      s->sensor_fd = open("/dev/v4l-subdev9", O_RDWR | O_NONBLOCK);
       break;
   }
   assert(s->sensor_fd >= 0);
```