### PR TITLE
Support for ethernet  over USB

### DIFF
--- a/drivers/usb/gadget/function/f_ncm.c
+++ b/drivers/usb/gadget/function/f_ncm.c
@@ -38,9 +38,7 @@
 
 /* to trigger crc/non-crc ndp signature */
 
-#define NCM_NDP_HDR_CRC_MASK	0x01000000
 #define NCM_NDP_HDR_CRC		0x01000000
-#define NCM_NDP_HDR_NOCRC	0x00000000
 
 enum ncm_notify_state {
 	NCM_NOTIFY_NONE,		/* don't notify */
@@ -530,6 +528,7 @@ static inline void ncm_reset_values(struct f_ncm *ncm)
 {
 	ncm->parser_opts = &ndp16_opts;
 	ncm->is_crc = false;
+	ncm->ndp_sign = ncm->parser_opts->ndp_sign;
 	ncm->port.cdc_filter = DEFAULT_FILTER;
 
 	/* doesn't make sense for ncm, fixed size used */
@@ -809,25 +808,21 @@ static int ncm_setup(struct usb_function *f, const struct usb_ctrlrequest *ctrl)
 	case ((USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE) << 8)
 		| USB_CDC_SET_CRC_MODE:
 	{
-		int ndp_hdr_crc = 0;
 
 		if (w_length != 0 || w_index != ncm->ctrl_id)
 			goto invalid;
 		switch (w_value) {
 		case 0x0000:
 			ncm->is_crc = false;
-			ndp_hdr_crc = NCM_NDP_HDR_NOCRC;
 			DBG(cdev, "non-CRC mode selected\n");
 			break;
 		case 0x0001:
 			ncm->is_crc = true;
-			ndp_hdr_crc = NCM_NDP_HDR_CRC;
 			DBG(cdev, "CRC mode selected\n");
 			break;
 		default:
 			goto invalid;
 		}
-		ncm->ndp_sign = ncm->parser_opts->ndp_sign | ndp_hdr_crc;
 		value = 0;
 		break;
 	}
@@ -844,6 +839,8 @@ invalid:
 			ctrl->bRequestType, ctrl->bRequest,
 			w_value, w_index, w_length);
 	}
+	ncm->ndp_sign = ncm->parser_opts->ndp_sign |
+			(ncm->is_crc ? NCM_NDP_HDR_CRC : 0);
 
 	/* respond with data transfer or status phase? */
 	if (value >= 0) {

--- a/drivers/usb/gadget/function/u_ether.c
+++ b/drivers/usb/gadget/function/u_ether.c
@@ -1414,10 +1414,14 @@ struct net_device *gether_setup_name_default(const char *netname)
 	dev->qmult = QMULT_DEFAULT;
 	snprintf(net->name, sizeof(net->name), "%s%%d", netname);
 
-	eth_random_addr(dev->dev_mac);
-	pr_warn("using random %s ethernet address\n", "self");
-	eth_random_addr(dev->host_mac);
-	pr_warn("using random %s ethernet address\n", "host");
+	// Hardcoded device MAC address. Not sure how to set this at runtime.
+	u8 hardcoded_dev_mac[ETH_ALEN] = {0x02, 0x01, 0x02, 0x03, 0x04, 0x05};
+	memcpy(dev->dev_mac, hardcoded_dev_mac, ETH_ALEN);
+	pr_warn("using hardcoded %s ethernet address for device\n", "self");
+	// Hardcoded host MAC address
+	u8 hardcoded_host_mac[ETH_ALEN] = {0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+	memcpy(dev->host_mac, hardcoded_host_mac, ETH_ALEN);
+	pr_warn("using hardcoded %s ethernet address for host\n", "host");
 
 	net->netdev_ops = &eth_netdev_ops;
 

--- a/drivers/usb/gadget/function/u_ether.c
+++ b/drivers/usb/gadget/function/u_ether.c
@@ -794,7 +794,7 @@ static netdev_tx_t eth_start_xmit(struct sk_buff *skb,
 	}
 
 	/* apply outgoing CDC or RNDIS filters */
-	if (!test_bit(RMNET_MODE_LLP_IP, &dev->flags) &&
+	if (skb && !test_bit(RMNET_MODE_LLP_IP, &dev->flags) &&
 			!is_promisc(cdc_filter)) {
 		u8		*dest = skb->data;
 


### PR DESCRIPTION
This allows users to setup and internet connection over usb and permits high speed low latency data throughput.

bug fix for configfs-gadget gadget: Wrong NDP SIGN. See https://blog.csdn.net/lovemengx/article/details/124953562

Here is the mainline linux kernal patch commit https://github.com/torvalds/linux/commit/550eef0c353030ac4223b9c9479bdf77a05445d6 for the Wrong NDP SIGN bug

and here is the commit which introduced the skb null pointer deref bug. It has since been removed from mainline https://github.com/torvalds/linux/commit/301fba0eb5676a3fe0732772f2b2b20b9b0959d8

Without this fix, I am unable to make a connection to the comma device with the ncm driver.


USB 3.0 connection:
```
PING 192.168.2.2 (192.168.2.2) 56(84) bytes of data.
64 bytes from 192.168.2.2: icmp_seq=1 ttl=64 time=4.26 ms
64 bytes from 192.168.2.2: icmp_seq=2 ttl=64 time=2.22 ms
64 bytes from 192.168.2.2: icmp_seq=3 ttl=64 time=2.18 ms
64 bytes from 192.168.2.2: icmp_seq=4 ttl=64 time=2.14 ms
64 bytes from 192.168.2.2: icmp_seq=5 ttl=64 time=2.55 ms
64 bytes from 192.168.2.2: icmp_seq=6 ttl=64 time=2.47 ms
64 bytes from 192.168.2.2: icmp_seq=7 ttl=64 time=2.64 ms
--- 192.168.2.2 ping statistics ---
7 packets transmitted, 7 received, 0% packet loss, time 6010ms
rtt min/avg/max/mdev = 2.136/2.636/4.263/0.687 ms

comma@tici:/data/openpilot$ iperf -s
------------------------------------------------------------
Server listening on TCP port 5001
TCP window size: 85.3 KByte (default)
------------------------------------------------------------
[  4] local 192.168.2.2 port 5001 connected with 192.168.2.1 port 53482
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0-10.0 sec   666 MBytes   556 Mbits/sec
```
This is the script I run on the comma device to setup the connection:


```
#!/bin/bash

# Define colors for output
OKGREEN='\033[92m'
FAIL='\033[91m'
ENDC='\033[0m'
BOLD='\033[1m'

# Set USB Gadget parameters
ID_VENDOR="0x1d6b"
ID_PRODUCT="0x0300"
BCD_DEVICE="0x0001"
BCD_USB="0x0300"

GADGET_PATH="/sys/kernel/config/usb_gadget/g1" #This path already exists. If you create a new gadget directory you will get a dir already exists error because /sys/devices/virtual/android_usb/android0/f_ECM already exists.
CONFIGS_PATH="$GADGET_PATH/configs/c.1"
ECM_FUNCTION_PATH="$GADGET_PATH/functions/ecm.0" # Select the Gadget driver by name here and adjust the settings for it below.

# Create and configure the USB gadget
mkdir -p $GADGET_PATH
echo $ID_VENDOR > $GADGET_PATH/idVendor
echo $ID_PRODUCT > $GADGET_PATH/idProduct
echo $BCD_DEVICE > $GADGET_PATH/bcdDevice
echo $BCD_USB > $GADGET_PATH/bcdUSB

# Create ECM function
mkdir -p $ECM_FUNCTION_PATH

# Remove existing configurations if they exist
rm -f $CONFIGS_PATH/f1
rm -f $CONFIGS_PATH/f2

# Create a configuration for the gadget
mkdir -p $CONFIGS_PATH
echo 250 > $CONFIGS_PATH/MaxPower # Max power in mA
echo 0x80 > $CONFIGS_PATH/bmAttributes

# Set up strings
mkdir -p $GADGET_PATH/strings/0x409
echo "0123456789" > $GADGET_PATH/strings/0x409/serialnumber
echo "Test" > $GADGET_PATH/strings/0x409/manufacturer
echo "Test ECM Gadget" > $GADGET_PATH/strings/0x409/product

# Link the ECM function to the configuration
ln -s $ECM_FUNCTION_PATH $CONFIGS_PATH

# Activate the gadget
echo "Activating Test ECM Gadget"
ls /sys/class/udc > $GADGET_PATH/UDC

# Check gadget state
STATE_FILE_PATH="/sys/devices/virtual/android_usb/android0/state"
RETRY=5
while [[ $RETRY -gt 0 ]]; do
    if [[ -f $STATE_FILE_PATH ]]; then
        STATE=$(cat $STATE_FILE_PATH)
        echo -e "${OKGREEN}ECM.0 usb is: ${STATE}${ENDC}"
        if [[ $STATE == "CONFIGURED" ]]; then
            break
        else
            echo -e "${BOLD}${FAIL}Warning: ECM USB activation failed! Checking $RETRY more time(s)${ENDC}${ENDC}"
            sleep 1
        fi
    else
        echo -e "${BOLD}${FAIL}File $STATE_FILE_PATH not found. IP over USB not possible.${ENDC}${ENDC}"
        exit 1
    fi
    RETRY=$((RETRY-1))
done

# Set up IP address
if ip addr add 192.168.2.2/24 dev usb0; then
    if ip link set usb0 up; then
        echo -e "${OKGREEN}IP address added to usb0 interface: 192.168.2.2/24${ENDC}"
    else
        echo "Failed to set usb0 up"
        exit 1
    fi
else
    echo "Failed to add IP address to usb0"
    exit 1
fi
```

Run this command on the PC to modify the udev rule so that you can leave the device plugged into the PC to skip fastboot mode on reboots.
```
echo 'ACTION=="add", \
SUBSYSTEM=="usb", \
ATTR{idVendor}=="18d1", \
ATTR{idProduct}=="d00d", \
RUN+="/bin/logger -t udev '\''Udev rule triggered for fastboot device'\''", \
RUN+="/usr/bin/fastboot continue"' | sudo tee /etc/udev/rules.d/51-android.rules && sudo udevadm control --reload-rules
````

