### PR TITLE
Revert "CPU freq governor, don't use freq above 1689600"

### DIFF
--- a/drivers/cpufreq/freq_table.c
+++ b/drivers/cpufreq/freq_table.c
@@ -43,7 +43,6 @@ int cpufreq_frequency_table_cpuinfo(struct cpufreq_policy *policy,
 
 	cpufreq_for_each_valid_entry(pos, table) {
 		freq = pos->frequency;
-    if (freq > 1689600) continue;
 
 		if (!cpufreq_boost_enabled()
 		    && (pos->flags & CPUFREQ_BOOST_FREQ))


### PR DESCRIPTION
This reverts commit f230c43d5d8d1b31488ae48235661131d0e7fa4a.