### PR TITLE
Add nullptr check in addrconf_rt_table

### DIFF
--- a/net/ipv6/addrconf.c
+++ b/net/ipv6/addrconf.c
@@ -2231,8 +2231,13 @@ u32 addrconf_rt_table(const struct net_device *dev, u32 default_table) {
 	 * - If < 0, put routes into table dev->ifindex + (-rt_table).
 	 */
 	struct inet6_dev *idev = in6_dev_get(dev);
+	int sysctl;
 	u32 table;
-	int sysctl = idev->cnf.accept_ra_rt_table;
+
+	if (!idev)
+		return default_table;
+
+	sysctl = idev->cnf.accept_ra_rt_table;
 	if (sysctl == 0) {
 		table = default_table;
 	} else if (sysctl > 0) {


### PR DESCRIPTION
This check/behavior is present in most other kernels (e.g. https://git.codelinaro.org/clo/la/kernel/msm-5.4/-/blame/kernel.lnx.5.4.r74-rel/net/ipv6/addrconf.c?page=3#L2380)