### PR TITLE
Lower jitter tolerance to get 60Hz back

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
@@ -82,7 +82,7 @@
 				qcom,mdss-dsi-v-top-border = <0>;
 				qcom,mdss-dsi-v-bottom-border = <0>;
 				qcom,mdss-dsi-panel-framerate = <60>;
-				qcom,mdss-dsi-panel-jitter = <0x3 0x1>;
+				qcom,mdss-dsi-panel-jitter = <0x4 0x1>;
 				qcom,mdss-dsi-on-command = [
 					05 01 00 00 0A 00 02 11 00
 					39 01 00 00 0A 00 05 2A 00 00 04 37

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
@@ -82,7 +82,7 @@
 				qcom,mdss-dsi-v-top-border = <0>;
 				qcom,mdss-dsi-v-bottom-border = <0>;
 				qcom,mdss-dsi-panel-framerate = <60>;
-				qcom,mdss-dsi-panel-jitter = <0xa 0x1>;
+				qcom,mdss-dsi-panel-jitter = <0x3 0x1>;
 				qcom,mdss-dsi-on-command = [
 					05 01 00 00 0A 00 02 11 00
 					39 01 00 00 0A 00 05 2A 00 00 04 37


### PR DESCRIPTION
- Original: 2% -> init issues on some panels in high temps
- Current: 10% (max setting) -> doesn't work timing-wise, display falls back to 30FPS
- This PR: 4% (highest that gives 60FPS) -> doesn't seem to suffer from the init issues on my test devices