### PR TITLE
Enable weak pullup on UART RX

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-pinctrl.dtsi
@@ -1580,29 +1580,29 @@
         mux {
           pins = "gpio78";
           function = "gpio";
-        };   
+        };
 
         config {
           pins = "gpio78";
           drive-strength = <2>;   /* 2 mA */
           bias-pull-down;         /* PULL DOWN */
           input-enable;
-        };   
-      };   
+        };
+      };
 
       tert_mi2s_sd1_active: tert_mi2s_sd1_active {
         mux {
           pins = "gpio78";
           function = "ter_mi2s";
-        };   
+        };
 
         config {
           pins = "gpio78";
           drive-strength = <8>;   /* 8 mA */
           bias-disable;           /* NO PULL */
-        };   
-      };   
-    };   
+        };
+      };
+    };
 
 		quat_mi2s_mclk {
 			quat_mi2s_mclk_sleep: quat_mi2s_mclk_sleep {
@@ -2622,14 +2622,27 @@
 		};
 
 		qupv3_se9_2uart_pins: qupv3_se9_2uart_pins {
-			qupv3_se9_2uart_active: qupv3_se9_2uart_active {
+			qupv3_se9_2uart_rx_active: qupv3_se9_2uart_rx_active {
 				mux {
-					pins = "gpio4", "gpio5";
+					pins = "gpio5";
 					function = "qup9";
 				};
 
 				config {
-					pins = "gpio4", "gpio5";
+					pins = "gpio5";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			qupv3_se9_2uart_tx_active: qupv3_se9_2uart_tx_active {
+				mux {
+					pins = "gpio4";
+					function = "qup9";
+				};
+
+				config {
+					pins = "gpio4";
 					drive-strength = <2>;
 					bias-disable;
 				};

--- a/arch/arm64/boot/dts/qcom/sdm845-qupv3.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-qupv3.dtsi
@@ -433,7 +433,7 @@
 			<&clock_gcc GCC_QUPV3_WRAP_1_M_AHB_CLK>,
 			<&clock_gcc GCC_QUPV3_WRAP_1_S_AHB_CLK>;
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&qupv3_se9_2uart_active>;
+		pinctrl-0 = <&qupv3_se9_2uart_rx_active>, <&qupv3_se9_2uart_tx_active>;
 		pinctrl-1 = <&qupv3_se9_2uart_sleep>;
 		interrupts = <GIC_SPI 354 0>;
 		qcom,wrapper-core = <&qupv3_1>;


### PR DESCRIPTION
On mici, the RX pin isn't connected to anything, so let's pull it up weakly to avoid high impedance noise.

Pullup isn't 2mA as advertised (measured more like 0.6mA), but that's still equivalent to a 3k pullup