### PR TITLE
bypass panic intended for wlan firmware debugging

### DIFF
--- a/drivers/soc/qcom/icnss.c
+++ b/drivers/soc/qcom/icnss.c
@@ -2456,9 +2456,11 @@ static int icnss_driver_event_pd_service_down(struct icnss_priv *priv,
 		goto out;
 	}
 
-	if (priv->force_err_fatal)
+	if (priv->force_err_fatal) {
 		// ICNSS_ASSERT(0);
 		icnss_pr_err("comma hax: skipping BUG_ON and proceeding with FW crash recovery");
+		priv->force_err_fatal = false;
+	}
 
 	if (priv->early_crash_ind) {
 		icnss_pr_dbg("PD Down ignored as early indication is processed: %d, state: 0x%lx\n",

--- a/drivers/soc/qcom/icnss.c
+++ b/drivers/soc/qcom/icnss.c
@@ -2457,7 +2457,8 @@ static int icnss_driver_event_pd_service_down(struct icnss_priv *priv,
 	}
 
 	if (priv->force_err_fatal)
-		ICNSS_ASSERT(0);
+		// ICNSS_ASSERT(0);
+		icnss_pr_err("comma hax: skipping BUG_ON and proceeding with FW crash recovery");
 
 	if (priv->early_crash_ind) {
 		icnss_pr_dbg("PD Down ignored as early indication is processed: %d, state: 0x%lx\n",


### PR DESCRIPTION
Potential mitigation for commaai/openpilot#35788. It looks like the WLAN firmware is crashing, and in the process, setting a development flag to force a kernel panic for debugging purposes. We can do without the panic.

The force_err_fatal flag was added in a standalone commit that explains how it works: https://android.googlesource.com/kernel/msm/+/3c2c7bf20432119e11105bd161ea5ddcedf4f116%5E%21/

If I'm understanding right, the sequence of events:

1) Either the WLAN FW or the driver tries to color outside the lines talking between WLAN and the host

2) ARM-SMMU frowns upon this, this is the visible start of the event

```
[38516.422393] arm-smmu 15000000.apps-smmu: Unhandled context fault: iova=0xac9e40d8, fsr=0x40000402, fsynr=0x80003, cb=5
[38516.422424] arm-smmu 15000000.apps-smmu: FAR    = 00000000ac9e40d8
[38516.422445] arm-smmu 15000000.apps-smmu: FSR    = 40000402 [TF SS ]
[38516.422465] arm-smmu 15000000.apps-smmu: soft iova-to-phys=0x0000000000000000
[38516.422484] arm-smmu 15000000.apps-smmu: SOFTWARE TABLE WALK FAILED! Looks like 15000000.apps-smmu accessed an unmapped address!
[38516.422504] arm-smmu 15000000.apps-smmu: hard iova-to-phys (ATOS) failed
[38516.422522] arm-smmu 15000000.apps-smmu: SID=0x40
[38516.422541] arm-smmu 15000000.apps-smmu: Unhandled arm-smmu context fault!
```

3) WLAN firmware seems to notice this or otherwise crash

4) WLAN firmware raises an optional debug-me development flag while dying

```
[38516.424565] icnss: Received force error fatal request from FW
```

5) The icnss kernel driver is [designed to panic](https://github.com/commaai/agnos-kernel-sdm845/blob/5eb331e66004ef69d640d49177900177e7e7e10f/drivers/soc/qcom/icnss.c#L144-L149) upon [receipt of this flag](https://github.com/commaai/agnos-kernel-sdm845/blob/5eb331e66004ef69d640d49177900177e7e7e10f/drivers/soc/qcom/icnss.c#L2460), and does so:

```
[38516.667361] icnss: ASSERT at line 2460
```

The SMMU should have saved us from the scribbling. After that, we can skip the panic and hopefully just proceed with recovery. Even if subsystem restart doesn't work, we'd much rather just lose WLAN than panic.