### PR TITLE
raise thermal limits for GPU and CPU LMH

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845.dtsi
@@ -3537,7 +3537,7 @@
 			thermal-governor = "step_wise";
 			trips {
 				pop_trip: pop-trip {
-					temperature = <95000>;
+					temperature = <105000>;
 					hysteresis = <0>;
 					type = "passive";
 				};

--- a/arch/arm64/boot/dts/qcom/sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845.dtsi
@@ -3490,7 +3490,7 @@
 			thermal-governor = "step_wise";
 			trips {
 				gpu_trip0: gpu-trip0 {
-					temperature = <95000>;
+					temperature = <105000>;
 					hysteresis = <0>;
 					type = "passive";
 				};

--- a/drivers/thermal/qcom/msm_lmh_dcvs.c
+++ b/drivers/thermal/qcom/msm_lmh_dcvs.c
@@ -566,12 +566,14 @@ static int limits_dcvs_probe(struct platform_device *pdev)
 		return -EINVAL;
 	};
 
-	/* Disabled to raise LMH throttling temperature */
+	/* COMMA: Disable LIMITS_SUB_FN_THERMAL and LIMITS_SUB_FN_CRNT LMH subfunctions to raise throttling temperature to ~105°C 
+	 * LIMITS_SUB_FN_REL and LIMITS_SUB_FN_BCL keep LMH functional */
+	/* Enable the thermal algorithm early */
 	ret = limits_dcvs_write(hw->affinity, LIMITS_SUB_FN_THERMAL,
 		 LIMITS_ALGO_MODE_ENABLE, 0, 0, 0);
 	if (ret)
 		return ret;
-	/* Disabled to raise LMH throttling temperature */
+	/* Enable the LMH outer loop algorithm */
 	ret = limits_dcvs_write(hw->affinity, LIMITS_SUB_FN_CRNT,
 		 LIMITS_ALGO_MODE_ENABLE, 0, 0, 0);
 	if (ret)

--- a/drivers/thermal/qcom/msm_lmh_dcvs.c
+++ b/drivers/thermal/qcom/msm_lmh_dcvs.c
@@ -566,14 +566,14 @@ static int limits_dcvs_probe(struct platform_device *pdev)
 		return -EINVAL;
 	};
 
-	/* Enable the thermal algorithm early */
+	/* Disabled to raise LMH throttling temperature */
 	ret = limits_dcvs_write(hw->affinity, LIMITS_SUB_FN_THERMAL,
-		 LIMITS_ALGO_MODE_ENABLE, 1, 0, 0);
+		 LIMITS_ALGO_MODE_ENABLE, 0, 0, 0);
 	if (ret)
 		return ret;
-	/* Enable the LMH outer loop algorithm */
+	/* Disabled to raise LMH throttling temperature */
 	ret = limits_dcvs_write(hw->affinity, LIMITS_SUB_FN_CRNT,
-		 LIMITS_ALGO_MODE_ENABLE, 1, 0, 0);
+		 LIMITS_ALGO_MODE_ENABLE, 0, 0, 0);
 	if (ret)
 		return ret;
 	/* Enable the Reliability algorithm */


### PR DESCRIPTION
The thermal limits are raised to ensure that, under normal operating conditions, these thresholds are never reached.
Oven heat tests confirmed that the thermal-zone DT trip configuration do not affect the CPU LMH throttling.

The throttling was triggered by two sub-functions: 
LIMITS_SUB_FN_THERMAL - temperature-based CPU frequency clamping
LIMITS_SUB_FN_CRNT - current-based CPU frequency clamping
There are two more subfunctions that keep LMH engaged, but at a higher limit of ~105°C.


Changes:
GPU (gpu_trip0): 95°C to 105°C
LMH DCVS (silver/gold): 95°C to ~105°C with disabling 2 LMH sub-functions.
RAM:  95°C to 105°C

| master| new | HW  | Triggers | Margin to Tjmax (125°C) |
|---------|-----------|----|----------------------------------------|-------------|
| 95°C  | 105°C   | RAM |RAM throttling gold cores| 20°C | 
| 95°C  | 105°C   | GPU | GPU clock throttling | 20°C  |
| 95°C  | ~105°C   | CPU |CPU clock throttling | 20°C | 

RAM temp stays ~10°C below CPU, RAM clocks remained stable through all thermal testing. Exceeding RAM limit was throttling gold cores at the same time as LMH. Raised to 105°C for margin.

Measured HW shutdown at ~119°C, this gives us 14°C of margin.

Validation with modified AGNOS:
```
paste <(cat /sys/class/thermal/thermal_zone*/type) <(cat /sys/class/thermal/thermal_zone*/trip_point_0_temp) | grep -E "step|lmh"
gpu-virt-max-step	105000 # changed
silv-virt-max-step	120000
gold-virt-max-step  120000
pop-mem-step	    95000
cpu0-silver-step	110000
cpu1-silver-step	110000
cpu2-silver-step	110000
cpu3-silver-step	110000
cpu0-gold-step	110000
cpu1-gold-step	110000
cpu2-gold-step	110000
cpu3-gold-step	110000
lmh-dcvs-01	  95000
lmh-dcvs-00	  95000
```