### PR TITLE
Set ELVSS to recommended -2.4V

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-bantian.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-bantian.dtsi
@@ -70,6 +70,7 @@
 				qcom,mdss-dsi-panel-framerate = <60>;
 				qcom,mdss-dsi-on-command = [
 					39 01 00 00 0A 00 02 FE 05
+					39 01 00 00 0A 00 02 2A 04
 					39 01 00 00 0A 00 02 91 00
 					39 01 00 00 0A 00 02 00 00
 					39 01 00 00 0A 00 02 FE 01


### PR DESCRIPTION
Match XBL change:

DWO recommended ELVSS is -2.4V instead of pmi8998 default of -5V. 

Extra feature is that screens that have "artifact issue" flaw harder to put into bad mode. 