### PR TITLE
faster power measurement

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -693,10 +693,10 @@ static int fg_get_battery_current(struct fg_chip *chip, int *val)
 	int64_t temp = 0;
 	u8 buf[2];
 
-	rc = fg_read(chip, BATT_INFO_IBATT_LSB(chip), buf, 2);
+	rc = fg_read(chip, BATT_INFO_IADC_LSB(chip), buf, 2);
 	if (rc < 0) {
 		pr_err("failed to read addr=0x%04x, rc=%d\n",
-			BATT_INFO_IBATT_LSB(chip), rc);
+			BATT_INFO_IADC_LSB(chip), rc);
 		return rc;
 	}
 
@@ -709,6 +709,12 @@ static int fg_get_battery_current(struct fg_chip *chip, int *val)
 	/* Sign bit is bit 15 */
 	temp = twos_compliment_extend(temp, 15);
 	*val = div_s64((s64)temp * BATT_CURRENT_NUMR, BATT_CURRENT_DENR);
+
+	/* Arm the next IADC conversion via rising edge on BATT_IADC_CONV. */
+	u8 iadc_ctrl = ALG_DIRECT_MODE_EN_BIT | ADC_ENABLE_REG_CTRL_BIT;
+	fg_write(chip, BATT_INFO_TM_MISC(chip), &iadc_ctrl, 1);
+	iadc_ctrl |= BATT_IADC_CONV_BIT;
+	fg_write(chip, BATT_INFO_TM_MISC(chip), &iadc_ctrl, 1);
 	return 0;
 }
 

--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -689,6 +689,7 @@ static int fg_get_battery_resistance(struct fg_chip *chip, int *val)
 #define BATT_CURRENT_DENR	1000
 static int fg_get_battery_current(struct fg_chip *chip, int *val)
 {
+	static int last_iadc_ua = 1;
 	int rc = 0;
 	int64_t temp = 0;
 	u8 buf[2];
@@ -709,6 +710,7 @@ static int fg_get_battery_current(struct fg_chip *chip, int *val)
 	/* Sign bit is bit 15 */
 	temp = twos_compliment_extend(temp, 15);
 	*val = div_s64((s64)temp * BATT_CURRENT_NUMR, BATT_CURRENT_DENR);
+	*val = *val ? (last_iadc_ua = *val) : last_iadc_ua;
 
 	/* Arm the next IADC conversion via rising edge on BATT_IADC_CONV. */
 	u8 iadc_ctrl = ALG_DIRECT_MODE_EN_BIT | ADC_ENABLE_REG_CTRL_BIT;

--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -714,7 +714,7 @@ static int fg_get_battery_current(struct fg_chip *chip, int *val)
 	*val = *val ? (last_iadc_ua = *val) : last_iadc_ua;
 
 	/* skip adc trigger while previous conversion is still running */
-	if (time_before(jiffies, last_trig + msecs_to_jiffies(167)))
+	if (time_before(jiffies, last_trig + msecs_to_jiffies(170)))
 		return 0;
 
 	/* arm the next IADC conversion with rising edge on BATT_IADC_CONV */

--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -690,6 +690,7 @@ static int fg_get_battery_resistance(struct fg_chip *chip, int *val)
 static int fg_get_battery_current(struct fg_chip *chip, int *val)
 {
 	static int last_iadc_ua = 1;
+	static unsigned long last_trig;
 	int rc = 0;
 	int64_t temp = 0;
 	u8 buf[2];
@@ -712,11 +713,16 @@ static int fg_get_battery_current(struct fg_chip *chip, int *val)
 	*val = div_s64((s64)temp * BATT_CURRENT_NUMR, BATT_CURRENT_DENR);
 	*val = *val ? (last_iadc_ua = *val) : last_iadc_ua;
 
-	/* Arm the next IADC conversion via rising edge on BATT_IADC_CONV. */
+	/* skip adc trigger while previous conversion is still running */
+	if (time_before(jiffies, last_trig + msecs_to_jiffies(167)))
+		return 0;
+
+	/* arm the next IADC conversion with rising edge on BATT_IADC_CONV */
 	u8 iadc_ctrl = ALG_DIRECT_MODE_EN_BIT | ADC_ENABLE_REG_CTRL_BIT;
 	fg_write(chip, BATT_INFO_TM_MISC(chip), &iadc_ctrl, 1);
 	iadc_ctrl |= BATT_IADC_CONV_BIT;
 	fg_write(chip, BATT_INFO_TM_MISC(chip), &iadc_ctrl, 1);
+	last_trig = jiffies;
 	return 0;
 }
 


### PR DESCRIPTION
SOM power measurement at up to 5.6 Hz via PMI8998 FG IADC direct mode, previously 0.7 Hz
Manually triggers the 15-bit delta-sigma IADC (163 ms/conversion, 488µA resolution)
Based on @robbederks test script: [hires_ibat_fg.py](https://github.com/commaai/tici_test_scripts/blob/5b025177fbb1e2a95c7059fb9a29953d83ff753a/fast_bat_read/hires_ibat_fg.py)

At 2 Hz, deviceState was reading ~3 stale power measurements before a new value was provided by the kernel, userspace change required raw register writes and mici/tici differentiation, better to implement it in the kernel.


Plot is for frequency comparison only, recorded at different loads.

<img width="2084" height="1031" alt="image" src="https://github.com/user-attachments/assets/389cd05f-f073-45de-b959-130a41ef402b" />
