### PR TITLE
arm64: dts: disable comma PCIe

### DIFF
--- a/arch/arm64/boot/dts/qcom/comma_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/comma_common.dtsi
@@ -41,6 +41,14 @@
   status = "disabled";
 };
 
+&pcie0 {
+  status = "disabled";
+};
+
+&pcie1 {
+  status = "disabled";
+};
+
 &soc {
 	clock_audio_lnbb: audio_ext_clk_lnbb {
 		status = "ok";


### PR DESCRIPTION
This costs us ~40ms at boot.