### PR TITLE
pil: avoid fallback for optional modem debug policy

### DIFF
--- a/drivers/soc/qcom/pil-msa.c
+++ b/drivers/soc/qcom/pil-msa.c
@@ -699,7 +699,7 @@ int pil_mss_reset_load_mba(struct pil_desc *pil)
 	md->attrs_dma |= DMA_ATTR_SKIP_ZEROING;
 	md->attrs_dma |= DMA_ATTR_STRONGLY_ORDERED;
 
-	ret = request_firmware(&dp_fw, dp_name, pil->dev);
+	ret = request_firmware_direct(&dp_fw, dp_name, pil->dev);
 	if (ret) {
 		dev_warn(pil->dev, "Debug policy not present - %s. Continue.\n",
 						dp_name);


### PR DESCRIPTION
Modem PIL requests optional `msadp` debug-policy firmware. When that file is absent and udev is masked, `request_firmware()` waits for the firmware fallback timeout before continuing.

Use `request_firmware_direct()` so the optional file fails fast from the filesystem path and modem boot continues immediately.

Tested: `./build_kernel.sh`; live device boot moved the `msadp` miss to ~5s instead of after the 60s fallback.