### PR TITLE
usb: gadget: f_ncm: Fix NTP-32 support (Windows NCM RX)

### DIFF
--- a/drivers/usb/gadget/function/f_ncm.c
+++ b/drivers/usb/gadget/function/f_ncm.c
@@ -38,9 +38,7 @@
 
 /* to trigger crc/non-crc ndp signature */
 
-#define NCM_NDP_HDR_CRC_MASK	0x01000000
 #define NCM_NDP_HDR_CRC		0x01000000
-#define NCM_NDP_HDR_NOCRC	0x00000000
 
 enum ncm_notify_state {
 	NCM_NOTIFY_NONE,		/* don't notify */
@@ -530,6 +528,7 @@ static inline void ncm_reset_values(struct f_ncm *ncm)
 {
 	ncm->parser_opts = &ndp16_opts;
 	ncm->is_crc = false;
+	ncm->ndp_sign = ncm->parser_opts->ndp_sign;
 	ncm->port.cdc_filter = DEFAULT_FILTER;
 
 	/* doesn't make sense for ncm, fixed size used */
@@ -809,25 +808,20 @@ static int ncm_setup(struct usb_function *f, const struct usb_ctrlrequest *ctrl)
 	case ((USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE) << 8)
 		| USB_CDC_SET_CRC_MODE:
 	{
-		int ndp_hdr_crc = 0;
-
 		if (w_length != 0 || w_index != ncm->ctrl_id)
 			goto invalid;
 		switch (w_value) {
 		case 0x0000:
 			ncm->is_crc = false;
-			ndp_hdr_crc = NCM_NDP_HDR_NOCRC;
 			DBG(cdev, "non-CRC mode selected\n");
 			break;
 		case 0x0001:
 			ncm->is_crc = true;
-			ndp_hdr_crc = NCM_NDP_HDR_CRC;
 			DBG(cdev, "CRC mode selected\n");
 			break;
 		default:
 			goto invalid;
 		}
-		ncm->ndp_sign = ncm->parser_opts->ndp_sign | ndp_hdr_crc;
 		value = 0;
 		break;
 	}
@@ -844,6 +838,8 @@ invalid:
 			ctrl->bRequestType, ctrl->bRequest,
 			w_value, w_index, w_length);
 	}
+	ncm->ndp_sign = ncm->parser_opts->ndp_sign |
+		(ncm->is_crc ? NCM_NDP_HDR_CRC : 0);
 
 	/* respond with data transfer or status phase? */
 	if (value >= 0) {


### PR DESCRIPTION
## Summary

Backport of mainline commit [`550eef0c3530`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=550eef0c353030ac4223b9c9479bdf77a05445d6) ("usb: gadget: f_ncm: Fix NTP-32 support", merged for v5.2). Fixes USB NCM RX from Windows 10/11 hosts.

## Problem

The AGNOS kernel (4.9.103) advertises both NTB16 and NTB32 datagram formats in `ntb_parameters.bmNtbFormatsSupported`. Windows 10/11 (`UsbNcm.sys`) negotiates NTB32 via `SET_NTB_FORMAT`, then sends NDP32 frames carrying signature `'NCM1'` (`0x314D434E`).

In the buggy code, `ncm->ndp_sign` is only assigned inside the `SET_CRC_MODE` control request handler:

```c
case ((USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE) << 8)
    | USB_CDC_SET_CRC_MODE:
    ...
    ncm->ndp_sign = ncm->parser_opts->ndp_sign | ndp_hdr_crc;
```

`SET_CRC_MODE` is optional and Windows does not send it. As a result, after `SET_NTB_FORMAT(NTB32)` switches `ncm->parser_opts` to `&ndp32_opts`, `ncm->ndp_sign` is never resynced and still contains the NDP16 sign `'NCM0'` (`0x304D434E`) from `ncm_reset_values()`'s implicit zero-init.

In `ncm_unwrap_ntb()`:

```c
if (get_unaligned_le32(tmp) != ncm->ndp_sign) {
    INFO(port->func.config->cdev, "Wrong NDP SIGN\n");
    goto err;
}
```

→ every IP packet from a Windows host is dropped with `Wrong NDP SIGN`. The USB-NCM link comes up electrically but passes zero traffic in the host→device direction.

## Fix

Recompute `ncm->ndp_sign` from `parser_opts->ndp_sign` (with the CRC bit if applicable) at the bottom of every `ncm_setup()` call, and seed it correctly in `ncm_reset_values()`. This keeps `ndp_sign` in sync with whatever format the host last selected, regardless of whether `SET_CRC_MODE` was sent.

This is the upstream commit verbatim — applies cleanly on top of `c368754c` (current AGNOS pin), no backport conflicts. The 4.9 file is structurally identical in this region.

## Cherry-pick details

```
commit e76d2810b292de84ef49508d50393f90ddddc8bb
Author: Romain Izard <romain.izard.pro@gmail.com>
    usb: gadget: f_ncm: Fix NTP-32 support
    ...
    (cherry picked from commit 550eef0c353030ac4223b9c9479bdf77a05445d6)
```

Diff: 1 file changed, 3 insertions(+), 7 deletions(-) — only `drivers/usb/gadget/function/f_ncm.c`.

## Verification

Builds cleanly via `./build_kernel.sh` in agnos-builder. Boot.img produced and signed.

Hardware verification not yet completed: the resulting boot.img is rejected by ABL on a production comma four (verified-boot signature mismatch — `vble-qti.key` in agnos-builder is not the production root-of-trust). Recovery via the GPT slot-fallback path worked as expected. A maintainer with a dev-keyed unit or signing access can confirm the runtime fix.

Expected behavior after flashing on a verified unit, with a Windows 10/11 host connected over USB:
- `dmesg | grep -i ncm` should be silent under traffic (no more `Wrong NDP SIGN`)
- `/sys/class/net/usb0/statistics/rx_packets` should increment when the host pings the device

## References

- Upstream commit: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=550eef0c353030ac4223b9c9479bdf77a05445d6
- Mainline merge: v5.2-rc1
