### PR TITLE
expose usb3 link err counter

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3218,21 +3218,19 @@ static ssize_t mode_store(struct device *dev, struct device_attribute *attr,
 static DEVICE_ATTR_RW(mode);
 
 static ssize_t portli_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
+			   struct device_attribute *attr, char *buf)
 {
 	struct dwc3_msm *mdwc = dev_get_drvdata(dev);
-	u32 portli = 0;
+	struct dwc3 *dwc = platform_get_drvdata(mdwc->dwc3);
+	int ret = -EAGAIN;
 
-	if (!mdwc->in_host_mode)
-		return scnprintf(buf, PAGE_SIZE, "0x%08x\n", 0);
+	mutex_lock(&mdwc->suspend_resume_mutex);
+	if (mdwc->in_host_mode && !atomic_read(&dwc->in_lpm))
+		ret = scnprintf(buf, PAGE_SIZE, "0x%08x\n",
+				dwc3_msm_read_reg(mdwc->base, USB3_PORTLI));
 
-	if (pm_runtime_get_sync(mdwc->dev) >= 0) {
-		portli = dwc3_msm_read_reg(mdwc->base, USB3_PORTLI);
-		pm_runtime_mark_last_busy(mdwc->dev);
-		pm_runtime_put_sync_autosuspend(mdwc->dev);
-	}
-
-	return scnprintf(buf, PAGE_SIZE, "0x%08x\n", portli);
+	mutex_unlock(&mdwc->suspend_resume_mutex);
+	return ret;
 }
 static DEVICE_ATTR_RO(portli);
 

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3222,6 +3222,9 @@ static ssize_t portli_show(struct device *dev,
 {
 	struct dwc3_msm *mdwc = dev_get_drvdata(dev);
 
+	if (!mdwc->in_host_mode)
+		return scnprintf(buf, PAGE_SIZE, "0x%08x\n", 0);
+
 	return scnprintf(buf, PAGE_SIZE, "0x%08x\n",
 			dwc3_msm_read_reg(mdwc->base, USB3_PORTLI));
 }

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3221,12 +3221,18 @@ static ssize_t portli_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct dwc3_msm *mdwc = dev_get_drvdata(dev);
+	u32 portli = 0;
 
 	if (!mdwc->in_host_mode)
 		return scnprintf(buf, PAGE_SIZE, "0x%08x\n", 0);
 
-	return scnprintf(buf, PAGE_SIZE, "0x%08x\n",
-			dwc3_msm_read_reg(mdwc->base, USB3_PORTLI));
+	if (pm_runtime_get_sync(mdwc->dev) >= 0) {
+		portli = dwc3_msm_read_reg(mdwc->base, USB3_PORTLI);
+		pm_runtime_mark_last_busy(mdwc->dev);
+		pm_runtime_put_sync_autosuspend(mdwc->dev);
+	}
+
+	return scnprintf(buf, PAGE_SIZE, "0x%08x\n", portli);
 }
 static DEVICE_ATTR_RO(portli);
 

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -77,6 +77,7 @@ MODULE_PARM_DESC(cpu_to_affin, "affin usb irq to this cpu");
 #define USB3_HCCPARAMS2		(0x1c)
 #define HCC_CTC(p)		((p) & (1 << 3))
 #define USB3_PORTSC		(0x420)
+#define USB3_PORTLI		(0x428)
 
 /**
  *  USB QSCRATCH Hardware registers
@@ -3215,6 +3216,17 @@ static ssize_t mode_store(struct device *dev, struct device_attribute *attr,
 }
 
 static DEVICE_ATTR_RW(mode);
+
+static ssize_t portli_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct dwc3_msm *mdwc = dev_get_drvdata(dev);
+
+	return scnprintf(buf, PAGE_SIZE, "0x%08x\n",
+			dwc3_msm_read_reg(mdwc->base, USB3_PORTLI));
+}
+static DEVICE_ATTR_RO(portli);
+
 static void msm_dwc3_perf_vote_work(struct work_struct *w);
 
 /* This node only shows max speed supported dwc3 and it should be
@@ -3701,6 +3713,7 @@ static int dwc3_msm_probe(struct platform_device *pdev)
 	device_create_file(&pdev->dev, &dev_attr_speed);
 	device_create_file(&pdev->dev, &dev_attr_usb_compliance_mode);
 	device_create_file(&pdev->dev, &dev_attr_xhci_link_compliance);
+	device_create_file(&pdev->dev, &dev_attr_portli);
 
 	host_mode = usb_get_dr_mode(&mdwc->dwc3->dev) == USB_DR_MODE_HOST;
 	if (!dwc->is_drd && host_mode) {
@@ -3740,6 +3753,7 @@ static int dwc3_msm_remove(struct platform_device *pdev)
 
 	device_remove_file(&pdev->dev, &dev_attr_mode);
 	device_remove_file(&pdev->dev, &dev_attr_xhci_link_compliance);
+	device_remove_file(&pdev->dev, &dev_attr_portli);
 	if (mdwc->usb_psy)
 		power_supply_put(mdwc->usb_psy);
 


### PR DESCRIPTION
Exposes the PORTLI Port link info register through sysfs to read usb3 link errors.