### PR TITLE
Work around stuck usb port

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -431,6 +431,26 @@ static bool dwc3_msm_is_host_superspeed(struct dwc3_msm *mdwc)
 	return false;
 }
 
+static bool dwc3_msm_ss_port_stuck(struct dwc3_msm *mdwc)
+{
+	u32 portsc;
+
+	/*
+	 * DWC3 exposes its single SuperSpeed root port after the USB2 root
+	 * port.  An unusable port in Polling cannot enter P3, so the QMP
+	 * PHY's autonomous receiver detector cannot become a wake source.
+	 */
+	portsc = dwc3_msm_read_reg(mdwc->base, USB3_PORTSC + 0x10);
+	if (portsc & PORT_CAS)
+		return false;
+
+	if ((portsc & PORT_CONNECT) && (portsc & PORT_PE))
+		return false;
+
+	return (portsc & PORT_PLS_MASK) == XDEV_POLLING ||
+	       (portsc & PORT_PLS_MASK) == XDEV_COMP_MODE;
+}
+
 static inline bool dwc3_msm_is_dev_superspeed(struct dwc3_msm *mdwc)
 {
 	u8 speed;
@@ -2115,8 +2135,23 @@ static void dwc3_msm_power_collapse_por(struct dwc3_msm *mdwc)
 
 static int dwc3_msm_prepare_suspend(struct dwc3_msm *mdwc)
 {
+	struct dwc3 *dwc = platform_get_drvdata(mdwc->dwc3);
+	struct usb_hcd *hcd;
 	unsigned long timeout;
 	u32 reg = 0;
+
+	/*
+	 * A missing CAS indication can leave the SuperSpeed port in Polling
+	 * after the root hub has suspended.  Keep the wrapper awake and
+	 * request a root-hub resume; xHCI will warm-reset the stuck port.
+	 */
+	if (mdwc->in_host_mode && dwc3_msm_ss_port_stuck(mdwc)) {
+		hcd = platform_get_drvdata(dwc->xhci);
+		usb_hcd_resume_root_hub(hcd_to_xhci(hcd)->shared_hcd);
+		dev_info(mdwc->dev,
+			 "SuperSpeed port stuck before suspend, resuming root hub\n");
+		return -EBUSY;
+	}
 
 	if ((mdwc->in_host_mode || mdwc->in_device_mode)
 			&& dwc3_msm_is_superspeed(mdwc) && !mdwc->in_restart) {
@@ -3957,6 +3992,7 @@ static void msm_dwc3_perf_vote_work(struct work_struct *w)
 static int dwc3_otg_start_host(struct dwc3_msm *mdwc, int on)
 {
 	struct dwc3 *dwc = platform_get_drvdata(mdwc->dwc3);
+	struct usb_hcd *hcd;
 	int ret = 0;
 
 	/*
@@ -4025,6 +4061,9 @@ static int dwc3_otg_start_host(struct dwc3_msm *mdwc, int on)
 			usb_unregister_notify(&mdwc->host_nb);
 			return ret;
 		}
+
+		hcd = platform_get_drvdata(dwc->xhci);
+		hcd_to_xhci(hcd)->quirks |= XHCI_MISSING_CAS;
 
 		/*
 		 * If the Compliance Transition Capability(CTC) flag of

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -436,9 +436,12 @@ static bool dwc3_msm_ss_port_stuck(struct dwc3_msm *mdwc)
 	u32 portsc;
 
 	/*
-	 * DWC3 exposes its single SuperSpeed root port after the USB2 root
-	 * port.  An unusable port in Polling cannot enter P3, so the QMP
-	 * PHY's autonomous receiver detector cannot become a wake source.
+	 * The DWC3 xHCI register block places the SuperSpeed PORTSC
+	 * immediately after the USB2 PORTSC, hence the 0x10 offset.
+	 *
+	 * The QMP PHY can use autonomous wake detection only after the
+	 * SuperSpeed link reaches U3. A port left in Polling or Compliance
+	 * therefore needs recovery before the PHY clocks can be gated.
 	 */
 	portsc = dwc3_msm_read_reg(mdwc->base, USB3_PORTSC + 0x10);
 	if (portsc & PORT_CAS)
@@ -2141,9 +2144,9 @@ static int dwc3_msm_prepare_suspend(struct dwc3_msm *mdwc)
 	u32 reg = 0;
 
 	/*
-	 * A missing CAS indication can leave the SuperSpeed port in Polling
-	 * after the root hub has suspended.  Keep the wrapper awake and
-	 * request a root-hub resume; xHCI will warm-reset the stuck port.
+	 * Do not suspend the Qualcomm wrapper while the SuperSpeed port
+	 * needs recovery. Wake the root hub so xHCI can warm-reset the port;
+	 * runtime PM will retry after the link has recovered.
 	 */
 	if (mdwc->in_host_mode && dwc3_msm_ss_port_stuck(mdwc)) {
 		hcd = platform_get_drvdata(dwc->xhci);

--- a/drivers/usb/host/xhci-hub.c
+++ b/drivers/usb/host/xhci-hub.c
@@ -1611,8 +1611,9 @@ static bool xhci_port_missing_cas_quirk(int port_index,
 
 	portsc = readl(port_array[port_index]);
 
-	/* if any of these are set we are not stuck */
-	if (portsc & (PORT_CONNECT | PORT_CAS))
+	/* CAS, or a connected and enabled port, means we are not stuck */
+	if ((portsc & PORT_CAS) ||
+	    ((portsc & PORT_CONNECT) && (portsc & PORT_PE)))
 		return false;
 
 	if (((portsc & PORT_PLS_MASK) != XDEV_POLLING) &&

--- a/drivers/usb/host/xhci-hub.c
+++ b/drivers/usb/host/xhci-hub.c
@@ -1611,7 +1611,7 @@ static bool xhci_port_missing_cas_quirk(int port_index,
 
 	portsc = readl(port_array[port_index]);
 
-	/* CAS, or a connected and enabled port, means we are not stuck */
+	/* CAS or a connected and enabled link does not need recovery. */
 	if ((portsc & PORT_CAS) ||
 	    ((portsc & PORT_CONNECT) && (portsc & PORT_PE)))
 		return false;


### PR DESCRIPTION
We hit this bug sporadically when re-enumerating USB3 devices, and they would get "stuck" until rebooting/repowering the device. This detects that scenario, and nudges it out of it.

Stable after hundreds of re-enumerations
