### PR TITLE
disable USB autosuspend for ASM2464

### DIFF
--- a/drivers/usb/core/driver.c
+++ b/drivers/usb/core/driver.c
@@ -1536,6 +1536,9 @@ int usb_resume(struct device *dev, pm_message_t msg)
  */
 void usb_enable_autosuspend(struct usb_device *udev)
 {
+	if (udev->quirks & USB_QUIRK_NO_AUTOSUSPEND)
+		return;
+
 	pm_runtime_allow(&udev->dev);
 }
 EXPORT_SYMBOL_GPL(usb_enable_autosuspend);
@@ -1851,6 +1854,9 @@ int usb_runtime_suspend(struct device *dev)
 {
 	struct usb_device	*udev = to_usb_device(dev);
 	int			status;
+
+	if (udev->quirks & USB_QUIRK_NO_AUTOSUSPEND)
+		return -EBUSY;
 
 	/* A USB device can be suspended if it passes the various autosuspend
 	 * checks.  Runtime suspend for a USB device means suspending all the

--- a/drivers/usb/core/quirks.c
+++ b/drivers/usb/core/quirks.c
@@ -258,6 +258,9 @@ static const struct usb_device_id usb_quirk_list[] = {
 	/* INTEL VALUE SSD */
 	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
 
+	/* comma ASM2464 bridge */
+	{ USB_DEVICE(0xadd1, 0x0001), .driver_info = USB_QUIRK_NO_AUTOSUSPEND },
+
 	{ }  /* terminating entry must be last */
 };
 

--- a/drivers/usb/core/quirks.c
+++ b/drivers/usb/core/quirks.c
@@ -258,7 +258,7 @@ static const struct usb_device_id usb_quirk_list[] = {
 	/* INTEL VALUE SSD */
 	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
 
-	/* comma ASM2464 bridge */
+	/* chestnut ASM2464 */
 	{ USB_DEVICE(0xadd1, 0x0001), .driver_info = USB_QUIRK_NO_AUTOSUSPEND },
 
 	{ }  /* terminating entry must be last */

--- a/drivers/usb/host/xhci-hub.c
+++ b/drivers/usb/host/xhci-hub.c
@@ -1202,14 +1202,6 @@ int xhci_hub_control(struct usb_hcd *hcd, u16 typeReq, u16 wValue,
 			/* Disable port */
 			if (link_state == USB_SS_PORT_LS_SS_DISABLED) {
 				xhci_dbg(xhci, "Disable port %d\n", wIndex);
-				slot_id = xhci_find_slot_id_by_port(hcd, xhci,
-						wIndex + 1);
-				if (slot_id) {
-					spin_unlock_irqrestore(&xhci->lock, flags);
-					xhci_stop_device(xhci, slot_id, 1);
-					spin_lock_irqsave(&xhci->lock, flags);
-					temp = readl(port_array[wIndex]);
-				}
 				temp = xhci_port_state_to_neutral(temp);
 				/*
 				 * Clear all change bits, so that we get a new

--- a/drivers/usb/host/xhci-hub.c
+++ b/drivers/usb/host/xhci-hub.c
@@ -1202,6 +1202,14 @@ int xhci_hub_control(struct usb_hcd *hcd, u16 typeReq, u16 wValue,
 			/* Disable port */
 			if (link_state == USB_SS_PORT_LS_SS_DISABLED) {
 				xhci_dbg(xhci, "Disable port %d\n", wIndex);
+				slot_id = xhci_find_slot_id_by_port(hcd, xhci,
+						wIndex + 1);
+				if (slot_id) {
+					spin_unlock_irqrestore(&xhci->lock, flags);
+					xhci_stop_device(xhci, slot_id, 1);
+					spin_lock_irqsave(&xhci->lock, flags);
+					temp = readl(port_array[wIndex]);
+				}
 				temp = xhci_port_state_to_neutral(temp);
 				/*
 				 * Clear all change bits, so that we get a new

--- a/include/linux/usb/quirks.h
+++ b/include/linux/usb/quirks.h
@@ -59,4 +59,7 @@
 /* Device needs a pause after every control message. */
 #define USB_QUIRK_DELAY_CTRL_MSG		BIT(13)
 
+/* Device can't reliably resume from runtime autosuspend. */
+#define USB_QUIRK_NO_AUTOSUSPEND		BIT(14)
+
 #endif /* __LINUX_USB_QUIRKS_H */


### PR DESCRIPTION
Disable autosuspend after enumerated ASM2464 has been hotplugged as this can leave the link in a degraded state.

Validation with test rack:
Attempt F2 transfer immediately after ASM FTDI-reset
master: 0/50 passed, enumerates but enters autosuspend so transfer fails
PR: 50/50 passed, enumerates and stays active, transfer succeeds