### PR TITLE
fix portli offset

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -77,7 +77,7 @@ MODULE_PARM_DESC(cpu_to_affin, "affin usb irq to this cpu");
 #define USB3_HCCPARAMS2		(0x1c)
 #define HCC_CTC(p)		((p) & (1 << 3))
 #define USB3_PORTSC		(0x420)
-#define USB3_PORTLI		(0x428)
+#define USB3_PORTLI		(0x438)
 
 /**
  *  USB QSCRATCH Hardware registers


### PR DESCRIPTION
This was pointing to USB2 PORTLI counter.
https://github.com/commaai/agnos-kernel-sdm845/blob/93ddd472ce522ab8669456b11bf3924ad32e9882/drivers/usb/dwc3/dwc3-msm.c#L439