### PR TITLE
tizi: reduce kernel boot critical path

### DIFF
--- a/arch/arm64/boot/dts/qcom/comma_tizi.dts
+++ b/arch/arm64/boot/dts/qcom/comma_tizi.dts
@@ -131,6 +131,23 @@
   qcom,dsi-pref-prim-pan = <&dsi_ss_fhd_ea8074_cmd>;
 };
 
+&snd_934x {
+  qcom,comma-skip-tavil-init;
+  qcom,comma-minimal-audio;
+  qcom,comma-tertiary-capture;
+
+  qcom,audio-routing =
+    "HiFi Playback", "IN_L",
+    "HiFi Playback", "IN_R",
+    "OUT_L", "HiFi Capture",
+    "OUT_R", "HiFi Capture";
+
+  asoc-platform = <&pcm0>, <&routing>;
+  asoc-platform-names = "msm-pcm-dsp.0", "msm-pcm-routing";
+  asoc-cpu = <&dai_mi2s1>, <&dai_mi2s2>;
+  asoc-cpu-names = "msm-dai-q6-mi2s.1", "msm-dai-q6-mi2s.2";
+};
+
 /* Panel */
 &dsi_mate10_lite_video {
   qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;

--- a/arch/arm64/configs/tici_defconfig
+++ b/arch/arm64/configs/tici_defconfig
@@ -1206,7 +1206,7 @@ CONFIG_RFKILL_LEDS=y
 # CONFIG_CAIF is not set
 # CONFIG_CEPH_LIB is not set
 # CONFIG_NFC is not set
-CONFIG_NFC_NQ=y
+# CONFIG_NFC_NQ is not set
 # CONFIG_LWTUNNEL is not set
 CONFIG_DST_CACHE=y
 # CONFIG_NET_DEVLINK is not set

--- a/drivers/input/touchscreen/hynitron_touch.c
+++ b/drivers/input/touchscreen/hynitron_touch.c
@@ -294,6 +294,7 @@ static struct i2c_driver hyn_ts_driver = {
 	.driver = {
 		.name	= HYN_I2C_NAME,
 		.of_match_table = of_match_ptr(hyn_ts_dt_ids),
+		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
 	},
 	.probe		= hyn_ts_probe,
     .remove     = hyn_ts_remove,

--- a/drivers/input/touchscreen/samsung_touch.c
+++ b/drivers/input/touchscreen/samsung_touch.c
@@ -898,6 +898,7 @@ static struct i2c_driver ss_ts_driver = {
 	.driver = {
 		.name	= SS_I2C_NAME,
 		.of_match_table = of_match_ptr(ss_ts_dt_ids),
+		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
 	},
 	.probe		= ss_ts_probe,
     .remove     = ss_ts_remove,

--- a/techpack/audio/asoc/sdm845.c
+++ b/techpack/audio/asoc/sdm845.c
@@ -6171,8 +6171,9 @@ static struct snd_soc_dai_link msm_tavil_snd_card_dai_links[
 #define MSM_COMMON_DAI_LINK_MEDIA1	0
 #define MSM_MI2S_DAI_LINK_SEC_RX	2
 #define MSM_MI2S_DAI_LINK_SEC_TX	3
+#define MSM_MI2S_DAI_LINK_TERT_TX	5
 
-static struct snd_soc_dai_link msm_mici_snd_card_dai_links[3];
+static struct snd_soc_dai_link msm_comma_snd_card_dai_links[3];
 
 #if 0
 static int msm_snd_card_tavil_late_probe(struct snd_soc_card *card)
@@ -6475,17 +6476,25 @@ static struct snd_soc_card *populate_snd_card_dailinks(struct device *dev)
 
 		if (of_property_read_bool(dev->of_node,
 					  "qcom,comma-minimal-audio")) {
-			total_links = ARRAY_SIZE(msm_mici_snd_card_dai_links);
-			memcpy(&msm_mici_snd_card_dai_links[0],
+			int capture_link = MSM_MI2S_DAI_LINK_SEC_TX;
+
+			if (of_property_read_bool(dev->of_node,
+						  "qcom,comma-tertiary-capture")) {
+				capture_link = MSM_MI2S_DAI_LINK_TERT_TX;
+				mi2s_tx_cfg[TERT_MI2S].channels = 2;
+			}
+
+			total_links = ARRAY_SIZE(msm_comma_snd_card_dai_links);
+			memcpy(&msm_comma_snd_card_dai_links[0],
 			       &msm_common_dai_links[MSM_COMMON_DAI_LINK_MEDIA1],
-			       sizeof(msm_mici_snd_card_dai_links[0]));
-			memcpy(&msm_mici_snd_card_dai_links[1],
+			       sizeof(msm_comma_snd_card_dai_links[0]));
+			memcpy(&msm_comma_snd_card_dai_links[1],
 			       &msm_mi2s_be_dai_links[MSM_MI2S_DAI_LINK_SEC_RX],
-			       sizeof(msm_mici_snd_card_dai_links[1]));
-			memcpy(&msm_mici_snd_card_dai_links[2],
-			       &msm_mi2s_be_dai_links[MSM_MI2S_DAI_LINK_SEC_TX],
-			       sizeof(msm_mici_snd_card_dai_links[2]));
-			dailink = msm_mici_snd_card_dai_links;
+			       sizeof(msm_comma_snd_card_dai_links[1]));
+			memcpy(&msm_comma_snd_card_dai_links[2],
+			       &msm_mi2s_be_dai_links[capture_link],
+			       sizeof(msm_comma_snd_card_dai_links[2]));
+			dailink = msm_comma_snd_card_dai_links;
 		} else {
 			len_1 = ARRAY_SIZE(msm_common_dai_links);
 			len_2 = len_1 + ARRAY_SIZE(msm_tavil_fe_dai_links);


### PR DESCRIPTION
## Summary

This applies the comma four minimal-audio boot optimization to comma 3X while preserving tizi's different capture topology.

- keep only the `MultiMedia1`, secondary MI2S playback, and tertiary MI2S capture DAI links used by tizi
- skip the unused Tavil codec initialization path
- configure tizi's tertiary capture link for two channels in the machine driver
- probe both possible tizi touchscreen controllers asynchronously
- remove the unused NFC NQ driver from `tici_defconfig`

The existing comma four minimal-audio change reduced sound-driver initialization from 1.7 s to 0.2 s. This gives tizi the same fast path, selecting tertiary rather than secondary capture to match its hardware and userspace mixer route.

## Verification

- full `./build_kernel.sh` completed successfully on a clean, case-sensitive APFS checkout
- modified audio and touchscreen sources plus `comma_tizi.dtb` compiled successfully
- final `Image-dtb`, modules, signed `output/boot.img`, and UAPI headers were produced
- `git diff --check` passed
- generated arm64 config contains `# CONFIG_NFC_NQ is not set`

The paired agnos-builder PR removes the now-unnecessary runtime channel control and updates the kernel submodule.

Closes commaai/openpilot#30894